### PR TITLE
fix request from submit

### DIFF
--- a/demo/project/static/src/utils/request.js
+++ b/demo/project/static/src/utils/request.js
@@ -123,6 +123,7 @@ const request = {
       _input.value = _value;
       _form.appendChild( _input );
     }
+    document.body.appendChild(_form);
     _form.submit();
 
   }


### PR DESCRIPTION
According to the HTML standards, if the form is not associated browsing context(document), form submission will be aborted.

> Form submission canceled because the form is not connected

[HTML SPEC](https://html.spec.whatwg.org/multipage/forms.html#form-submission-algorithm) see 4.10.21.3.2

In Chrome 56, this spec was applied.