### PR TITLE
链接不存在

### DIFF
--- a/note/start/info.md
+++ b/note/start/info.md
@@ -9,7 +9,7 @@
 │   └── response.js
 └── package.json
 ```
-这个就是GitHub[https://github.com/koajs/koa/tree/v2.x](https://github.com/koajs/koa/tree/v2.x)上开源的koa2源码的源文件结构，核心代码就是lib目录下的四个文件
+这个就是GitHub[https://github.com/koajs/koa](https://github.com/koajs/koa)上开源的koa2源码的源文件结构，核心代码就是lib目录下的四个文件
 
 - application.js 是整个koa2 的入口文件，封装了context，request，response，以及最核心的中间件处理流程。
 - context.js   处理应用上下文，里面直接封装部分request.js和response.js的方法


### PR DESCRIPTION
现在 master 版本即是 2.x，已经删除 tree 下面的 2.x 版本链接。